### PR TITLE
Revert "Update sonatype/nexus3 Docker tag to v3.73.0"

### DIFF
--- a/kubernetes/anvilpowered/nexus/deploy.yaml
+++ b/kubernetes/anvilpowered/nexus/deploy.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 200  # Group ID for volume
       containers:
         - name: nexus
-          image: sonatype/nexus3:3.73.0
+          image: sonatype/nexus3:3.70.1
           securityContext:
             runAsUser: 200  # User ID
           ports:

--- a/kubernetes/cluster-repository/nexus/deploy.yaml
+++ b/kubernetes/cluster-repository/nexus/deploy.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 200  # Group ID for volume
       containers:
         - name: nexus
-          image: sonatype/nexus3:3.73.0
+          image: sonatype/nexus3:3.70.1
           securityContext:
             runAsUser: 200  # User ID
           ports:

--- a/kubernetes/minecraft/nexus/deploy.yaml
+++ b/kubernetes/minecraft/nexus/deploy.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 200  # Group ID for volume
       containers:
         - name: nexus
-          image: sonatype/nexus3:3.73.0
+          image: sonatype/nexus3:3.70.1
           securityContext:
             runAsUser: 200  # User ID
           ports:


### PR DESCRIPTION
Reverts alexstaeding/homelab#78

Minor version bump is actually not so minor:

```
│ This instance is using a legacy Orient database.                                                                                                           │
│ You must migrate to H2 or PostgreSQL before upgrading to this version. See our database migration help documentation at:                                   │
│ https://links.sonatype.com/products/nxrm3/docs/unsupported-db. 
```